### PR TITLE
chore: refactor traefik configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,43 +1,22 @@
 services:
   traefik:
-    image: traefik:2.10
+    image: traefik:v3.1
     restart: unless-stopped
     ports:
       - "80:80"
       - "443:443"
-      - "8080:8080"
     volumes:
       - ./traefik.yml:/traefik.yml
       - /var/run/docker.sock:/var/run/docker.sock
-    container_name: traefik # Remove if using multiple instances
-    command:
-      # - "--log.level=DEBUG"
-      - "--api.insecure=true"
-      - "--providers.docker=true"
-      - "--providers.docker.exposedbydefault=false"
-      - "--entrypoints.websecure.address=:443"
-      - "--entrypoints.web.address=:80"
-      # - "--certificatesresolvers.myresolver.acme.tlschallenge=true"
-      # - "--certificatesresolvers.myresolver.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory"
-      # - "--certificatesresolvers.myresolver.acme.email=postmaster@example.com"
-      # - "--certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json"
+
+    container_name: traefik
     networks:
       - traefik
-      # Change if you're using another network
     labels:
-      # Traefik configuration for the dashboard
-      # Remove the labels section if the dashboard is disabled
-      - traefik.http.routers.traefik-http.rule=Host(`traefik.lh`)
       - traefik.http.routers.traefik-http.entrypoints=web
-      - traefik.http.routers.traefik-http.middlewares=redirect
-      - traefik.http.routers.traefik-https.rule=Host(`traefik.lh`)
-      - traefik.http.routers.traefik-https.entrypoints=websecure
-      - traefik.http.routers.traefik-https.tls=true
+      - traefik.http.routers.traefik-http.rule=Host(`traefik.lh`)
       - traefik.http.routers.traefik-http.service=api@internal
-      - traefik.http.routers.traefik-https.service=api@internal
-      - traefik.http.middlewares.redirect.redirectscheme.scheme=https
-      #- traefik.http.middlewares.redirect.redirectscheme.scheme=http
+
 networks:
-  # Change if you're using another network
   traefik:
     name: traefik

--- a/traefik.yml
+++ b/traefik.yml
@@ -4,6 +4,8 @@ api:
 log:
   level: DEBUG
 
+accessLog: {}
+
 entryPoints:
   web:
     address: ":80"

--- a/traefik.yml
+++ b/traefik.yml
@@ -1,6 +1,9 @@
 api:
   dashboard: true
 
+log:
+  level: DEBUG
+
 entryPoints:
   web:
     address: ":80"
@@ -11,18 +14,6 @@ providers:
   docker:
     network: traefik
 
-certificatesResolvers:
-  letsencrypt:
-    acme:
-      email: admin@example.com
-      storage: acme.json
-      httpChallenge:
-        entryPoint: web
-
-http:
-  routers:
-    api:
-      rule: Host(`local.services.fr`)
-      service: api@internal
-      middlewares:
-        - api-auth
+  # This allows Traefik to serve custom local certificates
+  file:
+    directory: /custom-config


### PR DESCRIPTION
# Use docker labels to configure traefik

![ruby](https://img.shields.io/badge/Ruby-informational?style=flat&logo=ruby&logoColor=white&color=CC0000)

## 🗃   Carte(s) Trello

[Mise en place de Traefik avec Docker - Outils et autres](https://trello.com/c/RSeeZIuZ)

## 🔀   Other

- Bump traefik to 3.1
- Use static configuration file instead of command (previously, docker command was overriding the provided static conf)
- Add custom dynamic configuration path to allow using local certificates (for touloisirs / arrivaj development)

## 📺   How to test

- in `touloisirs-scripts`, run `./scripts/dev`
